### PR TITLE
Add coverage analysis

### DIFF
--- a/.github/workflows/coverage-pages.yml
+++ b/.github/workflows/coverage-pages.yml
@@ -1,6 +1,12 @@
 name: Coverage pages
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'gh-pages'
+  pull_request:
+    branches-ignore:
+      - 'gh-pages'
 
 # Avoid race conditions
 concurrency:

--- a/.github/workflows/coverage-pages.yml
+++ b/.github/workflows/coverage-pages.yml
@@ -1,7 +1,6 @@
 name: Coverage pages
 
-on:
-  push:
+on: [push, pull_request]
 
 # Only run for most recent commit
 concurrency:

--- a/.github/workflows/coverage-pages.yml
+++ b/.github/workflows/coverage-pages.yml
@@ -1,0 +1,60 @@
+name: Coverage pages
+
+on:
+  push:
+
+# Only run for most recent commit
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🔔
+        uses: actions/checkout@v2
+
+      - name: Extract branch name 🔎
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
+      - name: Install Dart 🎯
+        uses: dart-lang/setup-dart@v1
+
+      - name: Install dependencies 📚
+        run: |
+          dart pub get
+          dart pub global activate coverage
+          dart pub global activate remove_from_coverage
+          sudo apt-get install -y lcov
+
+      - name: Run tests with coverage 🧪
+        run: dart test --coverage coverage
+
+      - name: Format coverage data 🔣
+        run: |
+          dart pub global run coverage:format_coverage -o coverage/lcov.info -i coverage -l --report-on lib --packages .packages
+          dart pub global run remove_from_coverage:remove_from_coverage -f coverage/lcov.info -r '\.g\.dart$'
+
+      - name: Generate report and index ⚙️
+        run: |
+          genhtml -o coverage/staging/${{ steps.extract_branch.outputs.branch }} coverage/lcov.info
+          touch coverage/staging/${{ steps.extract_branch.outputs.branch }}/.nojekyll
+          touch coverage/staging/.nojekyll
+
+      - name: Deploy to GH-Pages 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: coverage/staging
+          clean: no
+
+      - name: Upload to Codecov ☂️
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+          flags: unittests

--- a/.github/workflows/coverage-pages.yml
+++ b/.github/workflows/coverage-pages.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get install -y lcov
 
       - name: Run tests with coverage 🧪
-        run: dart test --coverage coverage
+        run: dart test -r expanded --coverage coverage
 
       - name: Format coverage data 🔣
         run: |

--- a/.github/workflows/coverage-pages.yml
+++ b/.github/workflows/coverage-pages.yml
@@ -2,13 +2,12 @@ name: Coverage pages
 
 on: [push, pull_request]
 
-# Only run for most recent commit
+# Avoid race conditions
 concurrency:
   group: ${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
-  build:
+  test-coverage:
     runs-on: ubuntu-latest
 
     steps:
@@ -38,7 +37,8 @@ jobs:
           dart pub global run coverage:format_coverage -o coverage/lcov.info -i coverage -l --report-on lib --packages .packages
           dart pub global run remove_from_coverage:remove_from_coverage -f coverage/lcov.info -r '\.g\.dart$'
 
-      - name: Generate report and index ⚙️
+      - name: Generate report ⚙️
+        if: ${{ github.event_name == 'push' }}
         run: |
           genhtml -o coverage/staging/${{ steps.extract_branch.outputs.branch }} coverage/lcov.info
           touch coverage/staging/${{ steps.extract_branch.outputs.branch }}/.nojekyll

--- a/.github/workflows/coverage-pages.yml
+++ b/.github/workflows/coverage-pages.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Deploy to GH-Pages 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.4
+        if: ${{ github.event_name == 'push' }}
         with:
           branch: gh-pages
           folder: coverage/staging

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/Coronon/flyde/branch/develop/graph/badge.svg?token=MG4AR31KY2)](https://codecov.io/gh/Coronon/flyde)
+
 # flyde
 
 _flyde_ is a command line tool, which boosts the productivity of C++ developers greatly.


### PR DESCRIPTION
This PR adds coverage analysis after each commit. It provides detailed coverage reports at [this repo's GH-Page](https://coronon.github.io/flyde/) and with [CodeCov](https://app.codecov.io/gh/Coronon/flyde). These reports are automatically generated in a GH-Action that runs after each commit.

The badge added to the README currently points to the 'develop' branch, as it represents the bleeding edge version of flyde.