### PR TITLE
Feature/improved vhook

### DIFF
--- a/test/core/async/event_synchronizer_test.dart
+++ b/test/core/async/event_synchronizer_test.dart
@@ -62,8 +62,8 @@ void main() {
   });
 
   test('Requests each stream item', () async {
-    final firstHook = VHook<bool?>(null);
-    final secondHook = VHook<bool?>(null);
+    final firstHook = VHook.empty();
+    final secondHook = VHook.empty();
 
     Stream<String> streamCreator() async* {
       yield 'test1';
@@ -72,18 +72,16 @@ void main() {
 
     client.onSent = (dynamic message) {
       if (message == 'test1') {
-        firstHook.set(true);
+        firstHook.complete();
       } else if (message == 'test2') {
-        secondHook.set(true);
+        secondHook.complete();
       }
     };
 
     await sync.request(streamCreator());
-    await firstHook.awaitValue(Duration(milliseconds: 1));
-    await secondHook.awaitValue(Duration(milliseconds: 1));
 
-    firstHook.expect(equals(true));
-    secondHook.expect(equals(true));
+    await firstHook.awaitCompletion(Duration(milliseconds: 1));
+    await secondHook.awaitCompletion(Duration(milliseconds: 1));
   });
 
   test('Can exchange a data stream', () async {
@@ -128,13 +126,13 @@ void main() {
   });
 
   test('Can ignore messages until the right one is received', () async {
-    final receivedHook = VHook<bool?>(null);
+    final receivedHook = VHook.empty();
     await sync.request('echo many');
     await sync.expect(
       String,
       validator: (String resp) {
         if (resp == 'right') {
-          receivedHook.set(true);
+          receivedHook.complete();
           return true;
         }
 
@@ -143,7 +141,6 @@ void main() {
       keepAlive: true,
     );
 
-    await receivedHook.awaitValue(Duration(milliseconds: 1));
-    receivedHook.expect(equals(true));
+    await receivedHook.awaitCompletion(Duration(milliseconds: 1));
   });
 }

--- a/test/helpers/value_hook.dart
+++ b/test/helpers/value_hook.dart
@@ -79,7 +79,7 @@ class VHook<T> {
     _stream.close();
 
     // Complete value
-    _completer.complete(_value);
+    hasValue ? _completer.complete(value) : _completer.complete();
   }
 
   /// Complete with an error or exception
@@ -245,7 +245,7 @@ class VHook<T> {
     if (onlyOnCompletion) {
       // Only check after completion
       await awaitCompletion(timeout);
-      
+
       test.expect(
         _value,
         matcher,
@@ -324,7 +324,7 @@ class VHook<T> {
     _assertNotCompletedError();
 
     // Check current value
-    if (wrappedCond(_value)) return _value;
+    if (hasValue ? wrappedCond(_value) : false) return _value;
 
     // Throw if already completed as no updates are expected
     _assertNotCompleted();

--- a/test/helpers/value_hook.dart
+++ b/test/helpers/value_hook.dart
@@ -205,6 +205,40 @@ class VHook<T> {
         skip: skip,
       );
 
+  /// Wait for the value to conform to [matcher].
+  ///
+  /// The optional [timeout] specifies the maximum time to wait for the match
+  /// before a [TimeoutException] is thrown. All intermidiate non-matching
+  /// states are ignored.
+  ///
+  /// This method uses 'expect' from the 'test' package.
+  ///
+  /// [matcher] is used to test for the expected value
+  /// e.g. `equals(true)`
+  Future<void> expectAsync(
+    test.Matcher matcher, {
+    String? reason,
+    dynamic skip,
+    Duration? timeout,
+  }) async =>
+      awaitValue(
+        timeout: timeout,
+        condition: (T val) {
+          try {
+            test.expect(
+              _value,
+              matcher,
+              reason: reason,
+              skip: skip,
+            );
+
+            return true;
+          } catch (e) {
+            return false;
+          }
+        },
+      );
+
   /// Get awaitable that completes when the contained value is set.
   ///
   /// The optional [timeout] specifies the maximum time to wait for the value

--- a/test/helpers/value_hook.dart
+++ b/test/helpers/value_hook.dart
@@ -2,41 +2,89 @@ import 'dart:async';
 
 import 'package:test/test.dart' as test show expect, Matcher;
 
-import 'wait_for.dart';
-
 /// Useful to easily test handler functions
 /// that set values outside of their scope.
 ///
 /// ```dart
-/// // Construct VHook with initial value of 'false'
-/// VHook<bool> calledHandler = VHook<bool>(false);
+/// // Construct VHook with no initial value'
+/// VHook calledHandler = VHook();
 ///
 /// willCallHandler(() {
-///   calledHandler.set(true);
 ///   // Some handler code
+///   // ...
+///   calledHandler.complete();
 /// });
 ///
 /// // Test that the handler was called
-/// // This will throw an error if the handler was not called.
-/// calledHandler.expect(equals(true));
+/// // If the handler was not called after 5s, throw an error
+/// calledHandler.awaitCompletion(Duration(seconds: 5));
 /// ```
 class VHook<T> {
   /// The value of the variable.
-  T _value;
+  dynamic _value;
+
+  /// Flag that indicates that the value reached it's final state.
+  final _completer = Completer<T>();
+
+  final _stream = StreamController<T>.broadcast();
 
   /// Construct a new ValueHook with the given initial value.
-  VHook(this._value);
+  ///
+  /// If not initial value is specified, a placeholder will
+  /// be used. Please check [hasValue] before directly accessing
+  /// [value] in such a case.
+  VHook([this._value = _VHookValue.none]);
 
   /// Set the value of the variable.
-  void set(T val) => _value = val;
+  void set(T val) {
+    // Do not change value if already completed
+    _assertNotCompleted();
 
-  /// Current value
+    // Update value
+    _value = val;
+
+    // Notify listeners
+    _stream.sink.add(val);
+  }
+
+  /// Complete with the given value.
+  void completeValue(T val) {
+    // Update value
+    set(val);
+
+    // Complete with newly updated value
+    complete();
+  }
+
+  /// Complete with the current value.
+  void complete() {
+    // Can not complete multiple times
+    _assertNotCompleted();
+
+    // Close stream
+    _stream.close();
+
+    // Complete value
+    _completer.complete(_value);
+  }
+
+  /// Obtain the current value.
+  ///
+  /// This will throw if no value has been assigned yet.
+  /// Check with [hasValue] before.
   T get value => _value;
+
+  /// Whether a value is present.
+  ///
+  /// Precondition before accessing [value].
+  bool get hasValue => _value != _VHookValue.none;
 
   /// Check the value of the variable.
   ///
   /// This method uses 'expect' from the 'test' package.
-  /// [val] is the expected value e.g. `equals(true)`
+  ///
+  /// [matcher] is used to test for the expected value
+  /// e.g. `equals(true)`
   void expect(
     test.Matcher matcher, {
     String? reason,
@@ -49,48 +97,120 @@ class VHook<T> {
         skip: skip,
       );
 
-  /// Get awaitable that completes when the contained value is non-null.
+  /// Get awaitable that completes when the contained value is set.
   ///
-  /// Note: The initial value of the VHook must have been null, and the final
-  /// value non-null.
-  ///
-  /// The optional [timeout] specifies the maximum time to wait for the value.
-  /// [pollInterval] specifies the time between value checks.
-  /// If [raiseOnTimeout] is true, this function will throw if the timeout is reached.
+  /// The optional [timeout] specifies the maximum time to wait for the value
+  /// before a [TimeoutException] is thrown.
+  /// You can specify a custom [condition] which takes the current value after
+  /// each update and must return a bool that indicates if it is met. Note that
+  /// [condition] is not called when the value is not yet set.
   ///
   /// The returned Future's completion value is whether the value was set (true)
   /// or whether the timeout was reached (false).
   ///
   /// ```dart
-  /// // Construct VHook with initial value of 'null'
-  /// VHook<bool?> conditionValue = VHook<bool?>(null);
+  /// // Construct VHook with no initial value
+  /// VHook<int> conditionValue = VHook<int>();
   ///
   /// // This function is supposed to call the handler soon
-  /// willCallHandlerAsync(() {
+  /// willCallHandlerAsyncRecurring(() {
   ///   if (someCondition) {
-  ///     conditionValue.set(true);
+  ///     conditionValue.set(42);
   ///   } else {
-  ///     conditionValue.set(false);
+  ///     conditionValue.set(17);
   ///   }
   /// });
   ///
-  /// // Wait for the handler to be called
-  /// // If the handler was not called after 5s, throw an error
-  /// await conditionValue.awaitValue(Duration(seconds: 5), raiseOnTimeout: true);
-  ///
-  /// // This will throw an error if the condition evaluated to false
-  /// conditionValue.expect(equals(true));
+  /// // Wait for the handler to be called and value set to <= 20
+  /// // If the conditions are not met after 5s, throw an error
+  /// await conditionValue.awaitValue(
+  ///   timeout: Duration(seconds: 5),
+  ///   condition: (int val) => val <= 20,
+  /// );
   /// ```
-  Future<bool> awaitValue(
-    Duration? timeout, {
-    Duration pollInterval = Duration.zero,
-    bool raiseOnTimeout = false,
-  }) async {
-    return waitFor(
-      () => _value != null,
-      timeout: timeout,
-      pollInterval: pollInterval,
-      raiseOnTimeout: raiseOnTimeout,
-    );
+  Future<T> awaitValue({Duration? timeout, bool Function(T)? condition}) async {
+    // Wrap condition to ensure correct handling
+    bool wrappedCond(dynamic val) {
+      // Don't test without value
+      if (val == _VHookValue.none) return false;
+
+      // Test condition if specified
+      if (condition != null) {
+        return condition(val);
+      }
+
+      // No custom condition specified, value recieved -> complete
+      return true;
+    }
+
+    // Check current value
+    if (wrappedCond(_value)) return _value;
+
+    // Throw if already completed as no updates are expected
+    _assertNotCompleted();
+
+    // Subscribe to changes and find first that satisfies [condition]
+    Future<dynamic> value = _stream.stream.firstWhere(wrappedCond);
+
+    // Add optional timeout
+    if (timeout != null) value = value.timeout(timeout);
+
+    // Wait for condition to be met and cast to avoid dynamic
+    return await value as T;
   }
+
+  /// Wait for and return the completed value.
+  ///
+  /// When specified [timeout] is waited for completion
+  /// before a [TimeoutException] is thrown.
+  ///
+  /// ```dart
+  /// // Construct VHook with no initial value
+  /// VHook<int> conditionValue = VHook<int>();
+  ///
+  /// // This function is supposed to call the handler soon
+  /// willCallHandlerAsyncRecurring(() {
+  ///   // These will not cause the [conditionValue] to complete
+  ///   if (someCondition) {
+  ///     conditionValue.set(42);
+  ///   } else {
+  ///     conditionValue.complete(17);
+  ///   }
+  ///
+  ///   // You have so specifically signal completion
+  ///   if (someRarerCondition) {
+  ///     conditionValue.complete();
+  ///   }
+  /// });
+  ///
+  /// // Wait for the conditionValue to be completed
+  /// // If not completed after 5s, throw an error
+  /// await conditionValue.awaitCompletion(timeout: Duration(seconds: 5));
+  /// ```
+  Future<T> awaitCompletion([Duration? timeout]) async {
+    if (timeout != null) {
+      return await _completer.future.timeout(
+        timeout,
+        onTimeout: () => throw TimeoutException('Timed out awaiting value'),
+      );
+    }
+
+    return await _completer.future;
+  }
+
+  /// Assert that the value is not yet completed
+  void _assertNotCompleted() {
+    if (_completer.isCompleted) {
+      throw StateError(
+        'VHook is completed with a value that does not satisfy the provided condition',
+      );
+    }
+  }
+}
+
+/// Enum that holds special value states for [VHook]
+enum _VHookValue {
+  /// Indicates that the [VHook] was not set to nor completed
+  /// with a value.
+  none
 }

--- a/test/helpers/value_hook.dart
+++ b/test/helpers/value_hook.dart
@@ -245,38 +245,33 @@ class VHook<T> {
     if (onlyOnCompletion) {
       // Only check after completion
       await awaitCompletion(timeout);
+      
+      test.expect(
+        _value,
+        matcher,
+        reason: reason,
+        skip: skip,
+      );
     } else {
       // Check all intermediate states
-      try {
-        await awaitValue(
-          timeout: timeout,
-          condition: (T val) {
-            try {
-              test.expect(
-                _value,
-                matcher,
-                reason: reason,
-                skip: skip,
-              );
+      await awaitValue(
+        timeout: timeout,
+        condition: (T val) {
+          try {
+            test.expect(
+              _value,
+              matcher,
+              reason: reason,
+              skip: skip,
+            );
 
-              return true;
-            } on test.TestFailure {
-              return false;
-            }
-          },
-        );
-      } on TimeoutException {
-        // We catch TimeoutException to show the results of
-        // matching the most current value (the [TestFailure])
-      }
+            return true;
+          } on test.TestFailure {
+            return false;
+          }
+        },
+      );
     }
-
-    test.expect(
-      _value,
-      matcher,
-      reason: reason,
-      skip: skip,
-    );
   }
 
   /// Get awaitable that completes when the contained value is set.

--- a/test/helpers/value_hook.dart
+++ b/test/helpers/value_hook.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart' as test show expect, Matcher, TestFailure;
 ///
 /// ```dart
 /// // Construct VHook with no initial value
-/// VHook calledHandler = VHook();
+/// VHook calledHandler = VHook.empty();
 ///
 /// willCallHandler(() {
 ///   // Some handler code
@@ -292,7 +292,7 @@ class VHook<T> {
   ///
   /// ```dart
   /// // Construct VHook with no initial value
-  /// VHook<int> conditionValue = VHook<int>();
+  /// VHook<int> conditionValue = VHook<int>.empty();
   ///
   /// // This function is supposed to call the handler soon
   /// willCallHandlerAsyncRecurring(() {
@@ -351,7 +351,7 @@ class VHook<T> {
   ///
   /// ```dart
   /// // Construct VHook with no initial value
-  /// VHook<int> conditionValue = VHook<int>();
+  /// VHook<int> conditionValue = VHook<int>.empty();
   ///
   /// // This function is supposed to call the handler soon
   /// willCallHandlerAsyncRecurring(() {

--- a/test/helpers/value_hook.dart
+++ b/test/helpers/value_hook.dart
@@ -205,6 +205,14 @@ class VHook<T> {
   /// Precondition before accessing [error].
   bool get hasError => _error != null;
 
+  /// Whether neither a value nor an error is present.
+  ///
+  /// Useful to check if [empty] constructed VHook was used.
+  ///
+  /// Note: If [complete] was called on the [VHook], this will
+  /// return false.
+  bool get isEmpty => !hasValue && !hasError && !_completer.isCompleted;
+
   /// Check the value of the variable.
   ///
   /// This method uses 'expect' from the 'test' package.

--- a/test/helpers/value_hook.dart
+++ b/test/helpers/value_hook.dart
@@ -106,8 +106,8 @@ class VHook<T> {
   /// [orElse] to provide a fallback in such a case. An error will be
   /// thrown if neither [updater] nor [orElse] can be used.
   ///
-  /// Please note that providing a wrapped `Future<T>` withing a [VHookValue]
-  /// to [orElse] will throw an [ArgumentError].
+  /// Please note that providing a wrapped `Future<T>` within a [ValueContainer]
+  /// to [orElse] will throw an [ArgumentError]. Use [updateAsync] instead.
   ///
   /// ```dart
   /// // Construct VHook with initial value
@@ -116,7 +116,7 @@ class VHook<T> {
   /// // Raise the current value (any value) to the power of two (x^2)
   /// int newVal = myHook.update((int val) => val*val);
   /// ```
-  T update(T Function(T) updater, {VHookValue<T>? orElse}) {
+  T update(T Function(T) updater, {ValueContainer<T>? orElse}) {
     // Do not change value if already completed
     _assertNotCompleted();
 
@@ -160,7 +160,7 @@ class VHook<T> {
   ///   (String name) async => await File(name).readAsString()
   /// );
   /// ```
-  Future<T> updateAsync(Future<T> Function(T) updater, {VHookValue<T>? orElse}) async {
+  Future<T> updateAsync(Future<T> Function(T) updater, {ValueContainer<T>? orElse}) async {
     // Do not change value if already completed
     _assertNotCompleted();
 
@@ -404,9 +404,9 @@ class VHook<T> {
 ///
 /// This is useful to distinguish  between the value `null`
 /// and 'argument not specified' for optional arguments.
-class VHookValue<T> {
+class ValueContainer<T> {
   /// Value encapsulated
   final FutureOr<T> value;
 
-  const VHookValue(this.value);
+  const ValueContainer(this.value);
 }


### PR DESCRIPTION
**Merge into _feature/build-server_**
**Closes #10** 

Rebuild `VHook` into a much more useful testing tool:


## No more need for optional

Always needing to use optional can be a pain, so we remove that requirement with this PR. You can now also use `null` like any other value as it does not represent an 'empty' `VHook` anymore.

```dart 
// VHook([dynamic = default])
final hook = VHook<int>();
```


## Completer like API including method to fail with an error

Would be more convenient for new devs as well. The `completeError` method would add value to `VHook`

```dart 
// void completeValue(T value)
hook.completeValue(0);

// void completeError(Exception exception) | or dynamic exception?
hook.completeError('Unfortunately 0 is not a number today. Try again tomorrow.');
```


## Method to set / modify the value without completing

Sometimes the value is important to really call the hook completed. Like when tracking active connections or any other counter.

```dart
// T update(T Function(T?));
hook.update((int? current) => current + 1 ?? 0);

// Future<T> updateAsync(Future<T> Function(T?));
hook.updateAsync((int? current) async => current + 1 ?? 0);

// void set(T);
hook.set(1);

// void complete();
// Completes the hook with the last value and skips possible handlers.
hook.finish();
```


## Method to await based on content

If no value handler is provided, the future completes when the first value arrives from any update method. This will throw if `complete` is called and the predicate does not evaluate to true, as it will be the final value and therefore the last chance for any value to satisfy the condition.

The method should always throw on timeout. Timeout is optional.
The return value is a Future to the awaited value.

```dart 
// Future<T> awaitValue(Duration timeout, [bool Function(T)? handler]);
hook.awaitValue(Duration(eternities: 66), (int value) => value > 2);
```


## Method to await based on completion

We sometimes only care about the final result, therefore awaiting completion would be nice.

```dart
// Future<T> awaitCompletion([Duration? timeout])
hook.awaitCompletion(timeout: Duration(seconds: 69));
```


## Combined expect and await method

This method could be used instead of `awaitValue` to instantly apply a matcher on completion or try matching on every change until succesfull (or timeout).

```dart 
// Future<T> expectAsync(Matcher matcher, {String? reason, dynamic skip, Duration? timeout});
hook.expectAsync(equals(3), timeout: Duration(eternities: 66));
```